### PR TITLE
[16.0][FIX] account_payment_term_discount: Correct discount amount when taxes excluded

### DIFF
--- a/account_payment_term_discount/models/account_move.py
+++ b/account_payment_term_discount/models/account_move.py
@@ -1,5 +1,7 @@
 # Copyright 2018 Open Source Integrators (http://www.opensourceintegrators.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from collections import defaultdict
+
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
@@ -88,3 +90,13 @@ class AccountMove(models.Model):
             ):
                 shipping_lines_total += line.price_subtotal
             invoice.shipping_lines_total = shipping_lines_total
+
+    def _get_invoice_counterpart_amls_for_early_payment_discount_per_payment_term_line(
+        self,
+    ):
+        res = (
+            super()._get_invoice_counterpart_amls_for_early_payment_discount_per_payment_term_line()  # noqa
+        )
+        if self.invoice_payment_term_id.is_exclude_taxes_discount:
+            res["tax_lines"] = defaultdict(lambda: {})
+        return res

--- a/account_payment_term_discount/wizard/account_payment_register.py
+++ b/account_payment_term_discount/wizard/account_payment_register.py
@@ -138,3 +138,27 @@ class AccountPaymentRegister(models.TransientModel):
                     }
                 )
         return res
+
+    def _get_total_amount_using_same_currency(
+        self, batch_result, early_payment_discount=True
+    ):
+        amount, mode = super()._get_total_amount_using_same_currency(
+            batch_result=batch_result, early_payment_discount=early_payment_discount
+        )
+        invoice = self.invoice_id
+        payment_term = invoice.invoice_payment_term_id
+        amount_untaxed = invoice.amount_untaxed_signed
+        if mode == "early_payment" and payment_term.is_exclude_taxes_discount:
+            amount, _ = super()._get_total_amount_using_same_currency(
+                batch_result=batch_result, early_payment_discount=False
+            )
+            payment_date = self.payment_date
+            if not payment_date:
+                payment_date = fields.Date.context_today(self)
+            else:
+                payment_date = fields.Date.from_string(payment_date)
+            payment_discount, _, _ = payment_term._get_payment_term_discount(
+                invoice=invoice, payment_date=payment_date, amount=amount_untaxed
+            )
+            amount -= payment_discount
+        return amount, mode


### PR DESCRIPTION
this PR is to address the issue from this comment: https://github.com/xaviedoanhduy/account-payment/pull/4#discussion_r2016087745

the current problem is that when we choose the option Exclude Taxes from Discount on the Payment Term, it seems that the discount value on the invoice does not change (it is always the discount value including tax).

suppose the invoice has 1 product with quantity is 10, unit price is 100 and tax is 15% (0.15) => invoice value 10 * 100 * 1.15 = 1150
if our payment due date is on time will be reduced by 5% (0.05) (including tax) then it will be reduced by 10 * 100 * 1.15 * 0.05 = 57.5. (1150 - 57.5 = 10925)
on the contrary (in case of excluding tax) with 5% discount then it will be reduced by 10 * 100 * 0.05 = 50. (1150 - 50 = 1100)
